### PR TITLE
Only update icon if necessary to improve performance

### DIFF
--- a/plugins/bluetooth/bluetooth.c
+++ b/plugins/bluetooth/bluetooth.c
@@ -1765,6 +1765,24 @@ static void update_device_list (BluetoothPlugin *bt)
 static void set_icon (LXPanel *p, GtkWidget *image, const char *icon, int size)
 {
     GdkPixbuf *pixbuf;
+
+	// Do nothing if icon to set matches current icon
+    static char * icon_last_set = NULL;
+    if (icon_last_set && !strcmp(icon_last_set, icon))
+    {
+        return;
+    }
+    
+    // Free up previous memory allocation
+    if (icon_last_set)
+    {
+        free(icon_last_set);
+        icon_last_set = NULL;
+    }
+    // Save current icon name
+    icon_last_set = (char *)malloc(strlen(icon) + 1);
+    strcpy(icon_last_set, icon);
+
     if (size == 0) size = panel_get_icon_size (p) - ICON_BUTTON_TRIM;
     if (gtk_icon_theme_has_icon (panel_get_icon_theme (p), icon))
     {

--- a/plugins/bluetooth/bluetooth.c
+++ b/plugins/bluetooth/bluetooth.c
@@ -1766,7 +1766,7 @@ static void set_icon (LXPanel *p, GtkWidget *image, const char *icon, int size)
 {
     GdkPixbuf *pixbuf;
 
-	// Do nothing if icon to set matches current icon
+    // Do nothing if icon to set matches current icon
     static char * icon_last_set = NULL;
     if (icon_last_set && !strcmp(icon_last_set, icon))
     {


### PR DESCRIPTION
Currently, the icon is set every time a new Bluetooth event occurs. This is unnecessary, and causes unnecessary CPU spikes. By caching the icon name, checking if the icon to be set matches, and updating only when necessary, the performance of the plugin is improved significantly.